### PR TITLE
fix(sanic): handle type casted path parameters

### DIFF
--- a/ddtrace/contrib/sanic/patch.py
+++ b/ddtrace/contrib/sanic/patch.py
@@ -60,7 +60,7 @@ def _get_path(request):
     except sanic.exceptions.SanicException:
         return path
     for key, value in match_info.items():
-        path = path.replace(value, f"<{key}>")
+        path = path.replace(str(value), f"<{key}>")
     return path
 
 

--- a/tests/contrib/sanic/test_sanic.py
+++ b/tests/contrib/sanic/test_sanic.py
@@ -54,10 +54,10 @@ def app(tracer):
         await random_sleep()
         return json({"hello": first_name})
 
-    @app.route("/hello/<first_name>/<surname>")
-    async def hello_multiple_params(request, first_name, surname):
+    @app.route("/hello/<first_name>/<surname>/<year:int>")
+    async def hello_multiple_params(request, first_name, surname, year):
         await random_sleep()
-        return json({"hello": f"{first_name} {surname}"})
+        return json({"hello": f"{first_name} {surname} {year}"})
 
     @app.route("/stream_response")
     async def stream_response(request):
@@ -186,7 +186,7 @@ async def test_basic_app(tracer, client, integration_config, integration_http_co
     "url, expected_json, expected_resource",
     [
         ("/hello/foo", {"hello": "foo"}, "GET /hello/<first_name>"),
-        ("/hello/foo/bar", {"hello": "foo bar"}, "GET /hello/<first_name>/<surname>"),
+        ("/hello/foo/bar/2020", {"hello": "foo bar 2020"}, "GET /hello/<first_name>/<surname>/<year>"),
     ],
 )
 async def test_resource_name(tracer, client, url, expected_json, expected_resource):


### PR DESCRIPTION
## Changes
 - Always cast path parameters to string. Currently it will throw an exception if a path parameter is type casted to an int/float.